### PR TITLE
URL redirecting and time span selection

### DIFF
--- a/conf-gen.py
+++ b/conf-gen.py
@@ -1,36 +1,52 @@
+import argparse
 import subprocess
 
 
-def get_external_lb_vip():
+def get_external_lb_vip(file_location=None):
     host = subprocess.check_output(["hostname"])
-    if "qe-iad3-3" in host:
+    if file_location:
+        fi = file_location
+    elif "qe-iad3-3" in host:
         h = "qe-iad3-lab03"
-        fi = "/opt/rpc-openstack/jenkins-oa/inventory/group_vars/{0}.yml".format(h)
+        fi = "/opt/rpc-openstack/jenkins-oa/inventory/group_vars/" \
+             "{0}.yml".format(h)
     elif "qe-iad3-2" in host:
         fi = "/etc/openstack_deploy/openstack_user_config.yml"
     else:
         raise Exception("conf-gen.py is for iad3-2 and iad3-3.")
 
-    elva = subprocess.check_output([
+    elva_line = subprocess.check_output([
         "grep", "-R", "external_lb_vip_address", fi])
+    elva = elva_line.split(":", 1)[1].strip()
     return elva
 
 
-def get_password():
-    password = subprocess.check_output([
-        "grep", "-R", "kibana_password",
-        "/etc/openstack_deploy/user_extras_secrets.yml"])
+def get_password(file_location=None):
+    file_location = (file_location
+                     or "/etc/openstack_deploy/user_extras_secrets.yml")
+    password_line = subprocess.check_output([
+        "grep", "-R", "kibana_password", file_location])
+    password = password_line.split(":", 1)[1].strip()
     return password
 
-vip = get_external_lb_vip()
-pas = get_password()
+if __name__ == '__main__':
+    description = "Script to generate config file"
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--password-file")
+    parser.add_argument("--vip-file")
+    parser.add_argument("--password")
+    parser.add_argument("--vip")
+    args = parser.parse_args()
 
-f = open('/opt/kibana-selenium/config/app.yaml', 'w')
-f.write("kibana:\n")
-f.close()
-append = open('/opt/kibana-selenium/config/app.yaml', 'a')
-append.write("  username: kibana\n")
-append.write("  "+pas)
-append.write(vip)
-append.close()
-print "Config file generated into config/app.yaml"
+    vip = args.vip or get_external_lb_vip(args.vip_file)
+    pas = args.password or get_password(args.password_file)
+
+    f = open('config/app.yaml', 'w+')
+    f.write("kibana:\n")
+    f.close()
+    append = open('config/app.yaml', 'a')
+    append.write("  username: kibana\n")
+    append.write("  kibana_password: {0}\n".format(pas))
+    append.write("  external_lb_vip_address: {0}".format(vip))
+    append.close()
+    print "Config file generated into config/app.yaml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ backports.shutil-get-terminal-size==1.0.0
 decorator==4.0.10
 ipython==5.0.0
 ipython-genutils==0.1.0
+nose==1.3.7
 pathlib2==2.1.0
 pexpect==4.2.0
 pickleshare==0.7.2

--- a/testrepo/kibana/kibana.py
+++ b/testrepo/kibana/kibana.py
@@ -52,16 +52,27 @@ class KibanaOne(unittest.TestCase):
             passwd = conf['kibana_password']
             ext_vip = conf['external_lb_vip_address']
             url = "https://{0}:{1}@{2}:8443/".format(user, passwd, ext_vip)
+            redirect_attempts = 5
             self.driver.get(url)
-            time.sleep(1)
+            while (url != self.driver.current_url) and (redirect_attempts > 0):
+                redirect_attempts -= 1
+                time.sleep(1)
+                url = self.driver.current_url
+                self.driver.get(url)
+                time.sleep(1)
             """
             element is used to ensure the page has fully
             loaded before we start accessing the page elements
             """
-            element = WebDriverWait(self.driver, 10).until(
+            time.sleep(15)
+            WebDriverWait(self.driver, 20).until(
                 ec.text_to_be_present_in_element((By.CSS_SELECTOR, ".name"),
                                                  "Home dashboard")
                 )
+            self.driver.implicitly_wait(20)
+            self.driver.find_element_by_class_name(
+                'navbar-timepicker-time-desc').click()
+            self.driver.find_element_by_link_text('Last 6 months').click()
             time.sleep(5)
         except Exception, e:
             self.driver.save_screenshot('setup.png')


### PR DESCRIPTION
I ran into two issues when running these tests against my Kibana dashboard. The first was that the base URL (https://<ip>:8443) redirects to something that looks like:

```
https://<ip>:8443/app/kibana#/dashboard/Home-dashboard?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(filters:!(),options:(darkTheme:!f),panels:!((col:1,id:Hint,panelIndex:1,row:1,size_x:12,size_y:1,type:visualization),(col:1,columns:!(beat.hostname,module,logmessage),id:default-search,panelIndex:2,row:2,size_x:12,size_y:6,sort:!('@timestamp',desc),type:search),(col:1,id:Log-Level-Severity,panelIndex:3,row:2,size_x:4,size_y:3,type:visualization),(col:7,id:Top-5-Event-Sources,panelIndex:4,row:2,size_x:5,size_y:3,type:visualization),(col:9,id:API-Operations,panelIndex:5,row:2,size_x:4,size_y:3,type:visualization),(col:5,id:OpenStack-Events-Histogram,panelIndex:6,row:2,size_x:4,size_y:3,type:visualization),(col:1,id:Infrastructure-Events-Histogram,panelIndex:8,row:2,size_x:4,size_y:3,type:visualization),(col:7,id:OpenStack-API-response-time,panelIndex:10,row:8,size_x:6,size_y:4,type:visualization),(col:1,id:OpenStack-API-comparing-response-time,panelIndex:11,row:8,size_x:6,size_y:4,type:visualization)),query:(query_string:(analyze_wildcard:!t,query:'*')),title:'Home%20dashboard',uiState:(P-3:(spy:(mode:(fill:!f,name:!n)),vis:(legendOpen:!t)),P-4:(vis:(legendOpen:!t)),P-5:(vis:(legendOpen:!t)),P-6:(spy:(mode:(fill:!f,name:!n)),vis:(legendOpen:!t)),P-8:(spy:(mode:(fill:!f,name:!n)),vis:(legendOpen:!f))))
```

Without going to that new URL, Kibana would have fail to load with a Courier Fetch Error, specifically `TypeError: 'undefined' is not an object (evaluating 'wgd.col')`. I'm guessing it's using the values in the redirected URL for rendering calculations.


The second issue was that the default time span for events was 15 minutes, so if there hadn't been any activity before 15 minutes, test_all_event_logs would fail. I added changing the time span to be 'Last 6 months' instead.

Lastly, I added nose to requirements so we can easily create xunit test reports. I picked nose just because that's what's used for the Horizon selenium tests, but if there's something more preferable, I can change it to that!
